### PR TITLE
Ensure proper eigen install

### DIFF
--- a/Superbuild/Projects/eigen.cmake
+++ b/Superbuild/Projects/eigen.cmake
@@ -3,4 +3,5 @@ add_external_project(eigen
     ${CMAKE_COMMAND} -E copy_if_different
     ${SuperBuild_PROJECTS_DIR}/patches/eigen.cmake.language_support.cmake
     <SOURCE_DIR>/cmake/language_support.cmake
+    CMAKE_ARGS -DEIGEN_BUILD_PKGCONFIG=off
   )


### PR DESCRIPTION
As detailed in this bug report http://eigen.tuxfamily.org/bz/show_bug.cgi?id=1100, Eigen will, even when doing a local install, sometimes try to install to somewhere in ```usr/```. This can be (correctly) avoided by turning off the ```EIGEN_BUILD_PKGCONFIG``` flag. 

This change ensures that Eigen builds and installs correctly as an external project.